### PR TITLE
Fix another typo

### DIFF
--- a/src/piece.rs
+++ b/src/piece.rs
@@ -171,7 +171,7 @@ impl core::fmt::Display for Piece {
                     Self::Rook(_, _) => "♜",
                     Self::Knight(_, _) => "♞",
                     Self::Bishop(_, _) => "♝",
-                    Self::Pawn(_, _) => "♟︎",
+                    Self::Pawn(_, _) => "♟",
                 },
             }
         )


### PR DESCRIPTION
This one fixes the misalignment of pawn pieces that appears on Windows, partially fixes #4